### PR TITLE
Tablenames, Export Databases, Export All Databases, Manager Mode

### DIFF
--- a/nmfDatabase/nmfDatabase.cpp
+++ b/nmfDatabase/nmfDatabase.cpp
@@ -1290,17 +1290,26 @@ nmfDatabase::exportDatabase(QWidget*     widget,
         QDir().mkpath(databaseDir);
     }
 
-    // Show file dialog and have user enter in the output .sql file name.
-    QString selFilter = "Database Files (*.sql)";
-    QString OutputFileName = QFileDialog::getSaveFileName(widget,
-        "Export Database",
-        databaseDir.toLatin1(),
-        "*.sql",
-        &selFilter,
-        QFileDialog::DontConfirmOverwrite);
-    if (OutputFileName.isEmpty())
-        return;
-    QApplication::flush();
+    QString OutputFileName;
+
+    if (ExportDatabaseWithFileName)
+    {
+         OutputFileName = QString::fromStdString(ProjectDatabase);
+    }
+    else
+    {
+        // Show file dialog and have user enter in the output .sql file name.
+        QString selFilter = "Database Files (*.sql)";
+        OutputFileName = QFileDialog::getSaveFileName(widget,
+            "Export Database",
+            databaseDir.toLatin1(),
+            "*.sql",
+            &selFilter,
+            QFileDialog::DontConfirmOverwrite);
+        if (OutputFileName.isEmpty())
+            return;
+        QApplication::flush();
+    }
 
     // Check for correct file extension and add one if it's not there or is incorrect.
     QFileInfo fi(OutputFileName);

--- a/nmfDatabase/nmfDatabase.h
+++ b/nmfDatabase/nmfDatabase.h
@@ -356,6 +356,7 @@ public:
                            std::string& Password);
 
     void exportDatabase(QWidget*     widget,
+						const bool   ExportDatabaseWithFileName,
                         std::string& ProjectDir,
                         std::string& Username,
                         std::string& Password,

--- a/nmfUtilities/nmfConstants.h
+++ b/nmfUtilities/nmfConstants.h
@@ -25,6 +25,8 @@ namespace nmfConstants
     EXTERN const bool   NoSignal = false;
     EXTERN const bool   RotateLabels = true;
     EXTERN const bool   DontRotateLabels = false;
+    EXTERN const bool   ExportDatabaseWithFileName = true;
+    EXTERN const bool   ExportDatabaseWithoutFileName = false;
 
     EXTERN const int    TYPE_PREDATOR       = 0;
     EXTERN const int    TYPE_PREY           = 1;


### PR DESCRIPTION
-Updated the functionality for viewing tablenames to be compatible with different computer resolutions.
-Implemented an Export All Databases feature that exports all MySQL databases from MSSPM.
-Added variables in nmfConstants for export databases.
-Added a message after you export a database to show that it successfully exported.
-Created a proof of concept gui for Manager Mode.